### PR TITLE
support https and pluggable dialers

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -15,6 +15,8 @@ type cachingDialer struct {
 	straightDialer Dialer
 }
 
+// NewCachingDialer takes an existing dialer and essentially memoizes the Dial
+// method with inactive connections.
 func NewCachingDialer(d Dialer) Dialer {
 	return &cachingDialer{
 		conns:          make(map[connKey][]Conn),
@@ -49,9 +51,11 @@ type cachedConn struct {
 }
 
 func (c *cachedConn) Release() {
+	c.Conn.Release()
 	c.cachingDialer.Lock()
 	defer c.cachingDialer.Unlock()
 	c.cachingDialer.conns[c.key] = append(c.cachingDialer.conns[c.key], c)
 }
 
+// DefaultCachingDialer is simply the DefaultDialer wrapped with a cache.
 var DefaultCachingDialer = NewCachingDialer(DefaultDialer)

--- a/cache.go
+++ b/cache.go
@@ -1,0 +1,57 @@
+package http
+
+import (
+	"sync"
+)
+
+type connKey struct {
+	scheme string
+	host   string
+}
+
+type cachingDialer struct {
+	sync.Mutex                        // protects following fields
+	conns          map[connKey][]Conn // maps call to a, possibly empty, slice of existing Conns
+	straightDialer Dialer
+}
+
+func NewCachingDialer(d Dialer) Dialer {
+	return &cachingDialer{
+		conns:          make(map[connKey][]Conn),
+		straightDialer: d}
+}
+
+func (d *cachingDialer) Dial(scheme, host string) (Conn, error) {
+	key := connKey{scheme: scheme, host: host}
+	d.Lock()
+	if c, ok := d.conns[key]; ok {
+		if len(c) > 0 {
+			conn := c[0]
+			c[0], c = c[len(c)-1], c[:len(c)-1]
+			d.Unlock()
+			return conn, nil
+		}
+	}
+	d.Unlock()
+
+	c, err := d.straightDialer.Dial(scheme, host)
+	return &cachedConn{
+		Conn:          c,
+		cachingDialer: d,
+		key:           key}, err
+}
+
+type cachedConn struct {
+	Conn
+
+	cachingDialer *cachingDialer
+	key           connKey
+}
+
+func (c *cachedConn) Release() {
+	c.cachingDialer.Lock()
+	defer c.cachingDialer.Unlock()
+	c.cachingDialer.conns[c.key] = append(c.cachingDialer.conns[c.key], c)
+}
+
+var DefaultCachingDialer = NewCachingDialer(DefaultDialer)

--- a/client.go
+++ b/client.go
@@ -14,7 +14,7 @@ import (
 // Client implements a high level HTTP client. Client methods can be called concurrently
 // to as many end points as required.
 type Client struct {
-	dialer Dialer
+	Dialer Dialer
 
 	// FollowRedirects instructs the client to follow 301/302 redirects when idempotent.
 	FollowRedirects bool
@@ -32,9 +32,6 @@ func (c *Client) Do(method, url string, headers map[string][]string, body io.Rea
 	}
 	host := u.Host
 	headers["Host"] = []string{host}
-	if !strings.Contains(host, ":") {
-		host += ":80"
-	}
 	path := u.Path
 	if path == "" {
 		path = "/"
@@ -42,7 +39,7 @@ func (c *Client) Do(method, url string, headers map[string][]string, body io.Rea
 	if u.RawQuery != "" {
 		path += "?" + u.RawQuery
 	}
-	conn, err := c.dialer.Dial("tcp", host)
+	conn, err := c.Dialer.Dial(u.Scheme, host)
 	if err != nil {
 		return client.Status{}, nil, nil, err
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -30,7 +30,7 @@ var clientDoTests = []struct {
 }{
 	{
 
-		Client:   Client{dialer: new(dialer)},
+		Client:   Client{Dialer: NewCachingDialer(dialer{})},
 		method:   "GET",
 		path:     "/200",
 		Status:   client.Status{200, "OK"},
@@ -39,7 +39,7 @@ var clientDoTests = []struct {
 	},
 	{
 
-		Client:   Client{dialer: new(dialer)},
+		Client:   Client{Dialer: NewCachingDialer(dialer{})},
 		method:   "GET",
 		path:     "/query1?a=1",
 		Status:   client.Status{200, "OK"},
@@ -48,7 +48,7 @@ var clientDoTests = []struct {
 	},
 	/** {
 
-	        Client:   Client{dialer: new(dialer)},
+	        Client:   Client{Dialer: NewCachingDialer(dialer{})},
 	        method:   "GET",
 	        path:     "/query1?a=1#ignored", // fragment should be ignored
 	        Status:   client.Status{200, "OK"},
@@ -57,7 +57,7 @@ var clientDoTests = []struct {
 	},     **/
 	{
 
-		Client:   Client{dialer: new(dialer)},
+		Client:   Client{Dialer: NewCachingDialer(dialer{})},
 		method:   "GET",
 		path:     "/query2?a=1&b=2",
 		Status:   client.Status{200, "OK"},
@@ -65,7 +65,7 @@ var clientDoTests = []struct {
 		rbody:    strings.NewReader("a=1&b=2"),
 	},
 	{
-		Client:   Client{dialer: new(dialer)},
+		Client:   Client{Dialer: NewCachingDialer(dialer{})},
 		method:   "GET",
 		path:     "/404",
 		Status:   client.Status{404, "Not Found"},
@@ -73,7 +73,7 @@ var clientDoTests = []struct {
 		rbody:    strings.NewReader("404 page not found\n"),
 	},
 	{
-		Client:   Client{dialer: new(dialer)},
+		Client:   Client{Dialer: NewCachingDialer(dialer{})},
 		method:   "GET",
 		path:     "/a",
 		Status:   client.Status{200, "OK"},
@@ -81,7 +81,7 @@ var clientDoTests = []struct {
 		rbody:    strings.NewReader(a()),
 	},
 	{
-		Client:  Client{dialer: new(dialer)},
+		Client:  Client{Dialer: NewCachingDialer(dialer{})},
 		method:  "GET",
 		path:    "/a",
 		Status:  client.Status{200, "OK"},
@@ -95,7 +95,7 @@ var clientDoTests = []struct {
 		rbody: strings.NewReader(a()),
 	},
 	{
-		Client:   Client{dialer: new(dialer)},
+		Client:   Client{Dialer: NewCachingDialer(dialer{})},
 		method:   "POST",
 		path:     "/201",
 		body:     func() io.Reader { return strings.NewReader(postBody) },
@@ -104,7 +104,7 @@ var clientDoTests = []struct {
 		rbody:    strings.NewReader("Created\n"),
 	},
 	{
-		Client: Client{dialer: new(dialer)},
+		Client: Client{Dialer: NewCachingDialer(dialer{})},
 		method: "GET",
 		path:   "/301",
 		Status: client.Status{301, "Moved Permanently"},
@@ -116,7 +116,7 @@ var clientDoTests = []struct {
 		rbody: strings.NewReader("<a href=\"/200\">Moved Permanently</a>.\n\n"),
 	},
 	{
-		Client: Client{dialer: new(dialer)},
+		Client: Client{Dialer: NewCachingDialer(dialer{})},
 		method: "GET",
 		path:   "/302",
 		Status: client.Status{302, "Found"},
@@ -128,7 +128,7 @@ var clientDoTests = []struct {
 		rbody: strings.NewReader("<a href=\"/200\">Found</a>.\n\n"),
 	},
 	{
-		Client:   Client{dialer: new(dialer), FollowRedirects: true},
+		Client:   Client{Dialer: NewCachingDialer(dialer{}), FollowRedirects: true},
 		method:   "GET",
 		path:     "/301",
 		Status:   client.Status{200, "OK"},
@@ -136,7 +136,7 @@ var clientDoTests = []struct {
 		rbody:    strings.NewReader("OK"),
 	},
 	{
-		Client:   Client{dialer: new(dialer), FollowRedirects: true},
+		Client:   Client{Dialer: NewCachingDialer(dialer{}), FollowRedirects: true},
 		method:   "GET",
 		path:     "/302",
 		Status:   client.Status{200, "OK"},
@@ -261,7 +261,7 @@ func TestClientGet(t *testing.T) {
 	s := newServer(t, stdmux())
 	defer s.Shutdown()
 	for _, tt := range clientGetTests {
-		c := &Client{dialer: new(dialer)}
+		c := &Client{Dialer: NewCachingDialer(dialer{})}
 		url := s.Root() + tt.path
 		status, _, _, err := c.Get(url, tt.headers)
 		if err != tt.err {
@@ -297,7 +297,7 @@ func TestClientPost(t *testing.T) {
 	s := newServer(t, stdmux())
 	defer s.Shutdown()
 	for _, tt := range clientPostTests {
-		c := &Client{dialer: new(dialer)}
+		c := &Client{Dialer: NewCachingDialer(dialer{})}
 		url := s.Root() + tt.path
 		var body io.Reader
 		if tt.body != nil {

--- a/conn.go
+++ b/conn.go
@@ -44,7 +44,12 @@ type dialer struct {
 	config tls.Config
 }
 
+// DefaultDialer is a non-caching dialer for a Client. It is strict with HTTPS
+// certificates
 var DefaultDialer = dialer{}
+
+// InsecureDialer is a non-caching dialer for a Client. It does not verify
+// peer certificates nor does it validate hostnames.
 var InsecureDialer = dialer{config: tls.Config{InsecureSkipVerify: true}}
 
 func (d dialer) Dial(scheme, host string) (Conn, error) {

--- a/conn.go
+++ b/conn.go
@@ -1,9 +1,12 @@
 package http
 
 import (
+	"crypto/tls"
+	"errors"
+	"fmt"
 	"io"
 	"net"
-	"sync"
+	"strings"
 	"time"
 
 	"github.com/gorilla/http/client"
@@ -11,35 +14,9 @@ import (
 
 // Dialer can dial a remote HTTP server.
 type Dialer interface {
-	// Dial dials a remote http server returning a Conn.
-	Dial(network, addr string) (Conn, error)
-}
-
-type dialer struct {
-	sync.Mutex                   // protects following fields
-	conns      map[string][]Conn // maps addr to a, possibly empty, slice of existing Conns
-}
-
-func (d *dialer) Dial(network, addr string) (Conn, error) {
-	d.Lock()
-	if d.conns == nil {
-		d.conns = make(map[string][]Conn)
-	}
-	if c, ok := d.conns[addr]; ok {
-		if len(c) > 0 {
-			conn := c[0]
-			c[0], c = c[len(c)-1], c[:len(c)-1]
-			d.Unlock()
-			return conn, nil
-		}
-	}
-	d.Unlock()
-	c, err := net.Dial(network, addr)
-	return &conn{
-		Client: client.NewClient(c),
-		Conn:   c,
-		dialer: d,
-	}, err
+	// Dial dials a remote http server returning a Conn having been requested
+	// using the given http scheme
+	Dial(scheme, host string) (Conn, error)
 }
 
 // Conn represnts a connection which can be used to communicate
@@ -59,12 +36,44 @@ type Conn interface {
 type conn struct {
 	client.Client
 	net.Conn
-	*dialer
 }
 
-func (c *conn) Release() {
-	c.dialer.Lock()
-	defer c.dialer.Unlock()
-	addr := c.Conn.RemoteAddr().String()
-	c.dialer.conns[addr] = append(c.dialer.conns[addr], c)
+func (c *conn) Release() {}
+
+type dialer struct {
+	config tls.Config
+}
+
+var DefaultDialer = dialer{}
+var InsecureDialer = dialer{config: tls.Config{InsecureSkipVerify: true}}
+
+func (d dialer) Dial(scheme, host string) (Conn, error) {
+	scheme = strings.ToLower(scheme)
+	switch scheme {
+	case "http":
+		if !strings.Contains(host, ":") {
+			host += ":80"
+		}
+		c, err := net.Dial("tcp", host)
+		if err != nil {
+			return nil, err
+		}
+		return &conn{
+			Client: client.NewClient(c),
+			Conn:   c}, nil
+	case "https":
+		if !strings.Contains(host, ":") {
+			host += ":443"
+		}
+		c, err := tls.Dial("tcp", host, &d.config)
+		if err != nil {
+			return nil, err
+		}
+
+		return &conn{
+			Client: client.NewClient(c),
+			Conn:   c}, nil
+	default:
+		return nil, errors.New(fmt.Sprintf("unsupported scheme: %s", scheme))
+	}
 }

--- a/conn_test.go
+++ b/conn_test.go
@@ -5,16 +5,19 @@ import (
 )
 
 var _ Conn = new(conn)
-var _ Dialer = new(dialer)
+var _ Dialer = DefaultCachingDialer
+var _ Dialer = DefaultDialer
+var _ Dialer = InsecureDialer
+var _ Dialer = NewCachingDialer(DefaultDialer)
 
 type countingDialer struct {
 	Dialer
 	count int
 }
 
-func (c *countingDialer) Dial(nw, addr string) (Conn, error) {
+func (c *countingDialer) Dial(scheme, addr string) (Conn, error) {
 	c.count++
-	return c.Dialer.Dial(nw, addr)
+	return c.Dialer.Dial(scheme, addr)
 }
 
 var dialCountTests = []struct {
@@ -22,32 +25,32 @@ var dialCountTests = []struct {
 	expected int // expected dial counts
 }{
 	{func(t *testing.T, s *server, d Dialer) {
-		conn, err := d.Dial("tcp", s.Addr().String())
+		conn, err := d.Dial("http", s.Addr().String())
 		if err != nil {
 			t.Fatal(err)
 		}
 		conn.Close()
 	}, 1},
 	{func(t *testing.T, s *server, d Dialer) {
-		conn, err := d.Dial("tcp", s.Addr().String())
+		conn, err := d.Dial("http", s.Addr().String())
 		if err != nil {
 			t.Fatal(err)
 		}
 		conn.Close()
-		conn, err = d.Dial("tcp", s.Addr().String())
+		conn, err = d.Dial("http", s.Addr().String())
 		if err != nil {
 			t.Fatal(err)
 		}
 		conn.Close()
 	}, 2},
 	{func(t *testing.T, s *server, d Dialer) {
-		conn, err := d.Dial("tcp", s.Addr().String())
+		conn, err := d.Dial("http", s.Addr().String())
 		if err != nil {
 			t.Fatal(err)
 		}
 		c1 := conn
 		conn.Release()
-		conn, err = d.Dial("tcp", s.Addr().String())
+		conn, err = d.Dial("http", s.Addr().String())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -64,7 +67,7 @@ func TestDialCounts(t *testing.T) {
 	defer s.Shutdown()
 
 	for i, tt := range dialCountTests {
-		d := countingDialer{Dialer: new(dialer)}
+		d := countingDialer{Dialer: DefaultCachingDialer}
 		tt.f(t, s, &d)
 		if actual := d.count; actual != tt.expected {
 			t.Errorf("TestDialCounts %d: expected %d, got %d", i, tt.expected, actual)

--- a/http.go
+++ b/http.go
@@ -20,7 +20,7 @@ import (
 // at the time, but may change over time. If you need more
 // control or reproducibility, you should construct your own client.
 var DefaultClient = Client{
-	dialer:          new(dialer),
+	Dialer:          DefaultCachingDialer,
 	FollowRedirects: true,
 }
 


### PR DESCRIPTION
closes #18 and #8

i'm unhappy that Dial matches the signature of net.Dial. :(

accepting network/address to the Dialer interface that does caching seems like the wrong abstraction layer here though, since we want to pool connections based on if they're ssl or not.

so, possible options: rename Dial to something else, Connect maybe? or maybe make some Scheme and Host types that are just strings?

i dunno.